### PR TITLE
Catch case of untagged images

### DIFF
--- a/kbase/collectd/docker_stats.py
+++ b/kbase/collectd/docker_stats.py
@@ -229,7 +229,10 @@ def read_func():
         # You can get the name but not tag of image from container attrs, so this
         # seems to be easiest method
         match = IMG_REGX.search(str(container.image))
-        image = match.group(1)
+        if match is None:
+            image = "untagged"
+        else:
+            image = match.group(1)
 
         instance = {"image": image,
                     "name": container.name,


### PR DESCRIPTION
This is to address the problem of the regex not matching for an image name in container.image. Turns out that if a running image hasn't been tagged, then container.image is set to "<Image: ''>". This catches that edge case and handles it.